### PR TITLE
nilrt_ip: Fix "ipv6" reference in _get_service_info() `data` map

### DIFF
--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -208,6 +208,8 @@ def _get_service_info(service):
             if value is None:
                 log.warning('Unable to get IPv6 %s for service %s\n', info, service)
                 continue
+            if 'ipv6' not in data:
+                data['ipv6'] = {}
             data['ipv6'][info.lower()] = [six.text_type(value)]
 
         nameservers = []


### PR DESCRIPTION
Fix exception reading IPv6 information. Touch `data['ipv6']` before attempting to reference it.

Testing: Verified `salt-call --local ip.set_dhcp_linklocal_all ens3` now works on a QEMU x64 machine.
