### PR TITLE
Fix typo in saltutil.py that causes jobs to fail

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -999,7 +999,7 @@ def is_running(fun):
     ret = []
     for data in run:
         function_data = data.get('fun', '')
-        if isinstance(functionData, list):
+        if isinstance(function_data, list):
             for function_item in function_data:
                 if fnmatch.fnmatch(function_item, fun):
                     ret.append(data)


### PR DESCRIPTION
### What does this PR do?
Fixes a typo in saltutil.py that makes jobs to fail

### Previous Behavior
some jobs would fail because functionData is not defined

### New Behavior
jobs do not fail anymore saying that functionData is not defined

### Tests written?
No

### Commits signed with GPG?
No
