### PR TITLE
Improve error handling in opkg salt module

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -591,13 +591,13 @@ def install(name=None,
             info={'errors': errors, 'changes': ret}
         )
 
+    _process_restartcheck_result(rs_result, **kwargs)
+
     if list_pkgs_errors:
         raise CommandExecutionError(
-            'Problem encountered after installing package(s). Cannot provide changes list.',
+            'Problem encountered after successfully installing package(s). Cannot provide changes list.',
             info={'errors': list_pkgs_errors}
         )
-
-    _process_restartcheck_result(rs_result, **kwargs)
 
     return ret
 
@@ -664,7 +664,7 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     old = _execute_list_pkgs(list_pkgs_errors, False)
     if list_pkgs_errors:
         raise CommandExecutionError(
-            'Problem encountered before installing package(s)',
+            'Problem encountered before removing package(s)',
             info={'errors': list_pkgs_errors}
         )
 
@@ -709,13 +709,13 @@ def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
             info={'errors': errors, 'changes': ret}
         )
 
+    _process_restartcheck_result(rs_result, **kwargs)
+
     if list_pkgs_errors:
         raise CommandExecutionError(
-            'Problem encountered after removing package(s). Cannot provide changes list.',
+            'Problem encountered after successfully removing package(s). Cannot provide changes list.',
             info={'errors': list_pkgs_errors}
         )
-
-    _process_restartcheck_result(rs_result, **kwargs)
 
     return ret
 
@@ -781,7 +781,7 @@ def upgrade(refresh=True, **kwargs):  # pylint: disable=unused-argument
     old = _execute_list_pkgs(list_pkgs_errors, False)
     if list_pkgs_errors:
         raise CommandExecutionError(
-            'Problem encountered before installing package(s)',
+            'Problem encountered before upgrading package(s)',
             info={'errors': list_pkgs_errors}
         )
 
@@ -805,13 +805,13 @@ def upgrade(refresh=True, **kwargs):  # pylint: disable=unused-argument
             info={'errors': errors, 'changes': ret}
         )
 
+    _process_restartcheck_result(rs_result, **kwargs)
+
     if list_pkgs_errors:
         raise CommandExecutionError(
-            'Problem encountered after upgrading package(s). Cannot provide changes list.',
+            'Problem encountered after successfully upgrading package(s). Cannot provide changes list.',
             info={'errors': list_pkgs_errors}
         )
-
-    _process_restartcheck_result(rs_result, **kwargs)
 
     return ret
 
@@ -1029,7 +1029,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     if errors:
         raise CommandExecutionError(
-            'Problem encountered installing package(s)',
+            'Problem encountered listing package(s)',
             info={'errors': errors}
         )
     return ret
@@ -1063,10 +1063,8 @@ def _execute_list_pkgs(errors, versions_as_list=False, **kwargs):
 
     if out_dict['retcode'] != 0:
         if out_dict['stderr']:
-            log.warning('error error')
             errors.append(out_dict['stderr'])
         else:
-            log.warning('error stdout')
             errors.append([out_dict['stdout']])
         return ret
 


### PR DESCRIPTION
### What does this PR do?
Improves error handling in opkg salt module in list_pkgs or in methods that call list_pkgs

### Previous Behavior
Install/Remove/Upgrade methods call list_pkgs before and after the actual operation in order to provide a list with the changes that were done. If list_pkgs failed to take the lock, the output of list_installed was a string that could not be parsed as a (package, version, description) list. Therefore the returned error was: 

`"Traceback (most recent call last):
  File \"/usr/lib/python3.5/site-packages/salt/minion.py\", line 1834, in _thread_multi_return
    ret['return'][ind] = func(*args, **kwargs)
  File \"/usr/lib/python3.5/site-packages/salt/modules/opkg.py\", line 545, in install
    new = list_pkgs()
  File \"/usr/lib/python3.5/site-packages/salt/modules/opkg.py\", line 1008, in list_pkgs
    pkg_name, pkg_version = line.split(' - ', 2)[:2]
ValueError: not enough values to unpack (expected 2, got 1)`

### New Behavior
If list_pkgs fails the returned error is the error that opkg returned.

### Tests written?
No

### Commits signed with GPG?
No