### PR TITLE
Pass kwargs from list_pkgs to _execute_list_pkgs

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -1025,7 +1025,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
         salt '*' pkg.list_pkgs versions_as_list=True
     '''
     errors = []
-    ret = _execute_list_pkgs(errors, versions_as_list)
+    ret = _execute_list_pkgs(errors, versions_as_list, **kwargs)
 
     if errors:
         raise CommandExecutionError(


### PR DESCRIPTION
### What does this PR do?
Fixes a bug introduced in #5 . In the mention PR a function was split in two, and the kwargs were not passed to the helper function. The bug was causing states to fail when applied.

### What issues does this PR fix or reference?

### Previous Behavior
States were failing when applied with error lowpkg.unpurge is not implemented

### New Behavior
State.apply is succeeding.

### Tests written?
No

### Commits signed with GPG?
No