### PR TITLE
fix: opkg retry condition

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -237,10 +237,10 @@ def _call_opkg(args, **kwargs):
         'python_shell': False,
     }
     params.update(kwargs)
-    for _ in range(5):
+    for idx in range(5):
         cmd_ret = __salt__['cmd.run_all'](args, **params)
         stderr = cmd_ret.get('stderr', '')
-        if 'opkg_lock: Could not lock /run/opkg.lock' in stderr:
+        if 'opkg_lock: Could not lock /run/opkg.lock' in stderr and idx < 4:
             import time
             time.sleep(2)
             continue


### PR DESCRIPTION
Previously if it was moving past 5,
the function returned None, and that
was used below to get 'retcode' and
whatnot, and was failing.
Now if the last attempt fails, return
that failed output.

Signed-off-by: Rares POP <rares.pop@ni.com>

