### PR TITLE
Add the jid to cdata kwargs in order to be passed to modules

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1848,6 +1848,7 @@ class State(object):
             initial_ret={'full': state_func_name},
             expected_extra_kws=STATE_INTERNAL_KEYWORDS
         )
+        cdata['kwargs']['__pub_jid'] = self.jid
         inject_globals = {
             # Pass a copy of the running dictionary, the low state chunks and
             # the current state dictionaries.


### PR DESCRIPTION
We need the jid in the execution modules ran from state
to be able to publish the software installation progress
information.

Signed-off-by: Cristian Hotea <cristian.hotea@ni.com>
