### PR TITLE
Fix state modules failing with unexpected kwarg __pub_jid

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1910,7 +1910,7 @@ class State(object):
             initial_ret={'full': state_func_name},
             expected_extra_kws=STATE_INTERNAL_KEYWORDS
         )
-        cdata['kwargs']['__pub_jid'] = self.jid
+
         inject_globals = {
             # Pass a copy of the running dictionary, the low state chunks and
             # the current state dictionaries.
@@ -1919,7 +1919,8 @@ class State(object):
             '__low__': immutabletypes.freeze(low),
             '__running__': immutabletypes.freeze(running) if running else {},
             '__instance_id__': self.instance_id,
-            '__lowstate__': immutabletypes.freeze(chunks) if chunks else {}
+            '__lowstate__': immutabletypes.freeze(chunks) if chunks else {},
+            '__jid__': self.jid
         }
 
         if '__env__' in low:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1595,6 +1595,7 @@ def installed(
             pkgs = [name]
 
     kwargs['saltenv'] = __env__
+    kwargs['__pub_jid'] = __jid__
     refresh = salt.utils.pkg.check_refresh(__opts__, refresh)
 
     # check if capabilities should be checked and modify the requested packages
@@ -2465,6 +2466,7 @@ def latest(
             desired_pkgs = [name]
 
     kwargs['saltenv'] = __env__
+    kwargs['__pub_jid'] = __jid__
 
     # check if capabilities should be checked and modify the requested packages
     # accordingly.
@@ -2855,6 +2857,7 @@ def removed(name,
         .. versionadded:: 0.16.0
     '''
     kwargs['saltenv'] = __env__
+    kwargs['__pub_jid'] = __jid__
     try:
         return _uninstall(action='remove', name=name, version=version,
                           pkgs=pkgs, normalize=normalize,
@@ -2961,6 +2964,7 @@ def purged(name,
     .. versionadded:: 0.16.0
     '''
     kwargs['saltenv'] = __env__
+    kwargs['__pub_jid'] = __jid__
     try:
         return _uninstall(action='purge', name=name, version=version,
                           pkgs=pkgs, normalize=normalize,


### PR DESCRIPTION
### What does this PR do?
Fixes a bug where applying states that contained state functions that did not support kwargs failed with the following erorr: "got an unexpected keyword argument '__pub_jid'"

### What issues does this PR fix or reference?
This was introduced by #13 and is needed by the software installation progress to work.

### Previous Behavior
__pub_jid was passed using kwargs which broke state functions that did not support kwargs

### New Behavior
__pub_jid is injected using global variables in state modules. state modules can then forward this to execution modules using kwargs

### Tests written?
No. 

### Commits signed with GPG?
No