### PR TITLE
add update feeds error as inner error for the install response

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -550,13 +550,10 @@ def install(name=None,
     if not cmds:
         return {}
 
-    updated_feeds = {}
+    feeds_updated_status = {}
     if refreshdb:
-        updated_feeds = refresh_db()
-    failed_to_update_feeds = []
-    for feed in updated_feeds:
-        if not updated_feeds[feed]:
-            failed_to_update_feeds.append(feed)
+        feeds_updated_status = refresh_db()
+    failed_to_update_feeds = [feed for feed in feeds_updated_status if not feeds_updated_status[feed]]
     feed_update_error = None
     if failed_to_update_feeds:
         feed_update_error = 'Error getting repos: {0}'.format(', '.join(failed_to_update_feeds))

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -550,9 +550,16 @@ def install(name=None,
     if not cmds:
         return {}
 
+    updated_feeds = {}
     if refreshdb:
-        refresh_db()
-
+        updated_feeds = refresh_db()
+    failed_to_update_feeds = []
+    for feed in updated_feeds:
+        if not updated_feeds[feed]:
+            failed_to_update_feeds.append(feed)
+    feed_update_error = None
+    if failed_to_update_feeds:
+        feed_update_error = 'Error getting repos: {0}'.format(', '.join(failed_to_update_feeds))
     errors = []
     is_testmode = _is_testmode(**kwargs)
     test_packages = {}
@@ -593,6 +600,8 @@ def install(name=None,
     rs_result = _get_restartcheck_result(errors)
 
     if errors:
+        if feed_update_error:
+            errors.append(feed_update_error)
         raise CommandExecutionError(
             'Problem encountered installing package(s)',
             info={'errors': errors, 'changes': ret}


### PR DESCRIPTION
### What does this PR do?
Adds the update feeds error if the install operation fails if they exist.
### What issues does this PR fix or reference?
https://ni.visualstudio.com/DevCentral/_workitems/edit/1049166
### Previous Behavior
When an install operation failed due to update failing of a feed, the error was misleading saying only that it could not get the corresponding package.

### New Behavior
Te error now contains the message that says that the corresponding feeds could not be updated.

### Tests written?
Not yet
