### PR TITLE
Do not automatically clean minion id in gen.key_accept

### DIFF
--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -411,7 +411,6 @@ def gen_accept(id_, keysize=2048, force=False):
         >>> wheel.cmd('key.list', ['accepted'])
         {'minions': ['foo', 'minion1', 'minion2', 'minion3']}
     '''
-    id_ = clean.id(id_)
     ret = gen(id_, keysize)
     acc_path = os.path.join(__opts__['pki_dir'], 'minions', id_)
     if os.path.isfile(acc_path) and not force:


### PR DESCRIPTION
### What does this PR do?
Remove minion id sanitize logic from gen.key_accept 

### Previous Behavior
Calling gen.key_accept for a minion_id that contains underscores (such as "a_b") will generate a key and accept it for minion_id "ab". Running a salt-key shows that the approved minion is: "ab", (and not "a_b" which is the real minion id). Because of this the minion cannot connect to the master.

### New Behavior
Calling gen.key_accept for a minion_id that contains underscores (such as "a_b") will generate a key and accept it for minion_id "ab". Running a salt-key shows that the approved minion is: "a_b". The minion can connect to the master.