### PR TITLE
Add support for operators in version

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -534,25 +534,25 @@ def install(name=None,
                         to_install.append(pkgstr)
                         cmd_prefix.append('--force-downgrade')
                     else:
-                pkgstr = '{0}={1}'.format(pkgname, version_num)
-                if reinstall and cver and salt.utils.versions.compare(
-                        ver1=version_num,
-                        oper='==',
-                        ver2=cver,
-                        cmp_func=version_cmp):
-                    to_reinstall.append(pkgstr)
-                elif not cver or salt.utils.versions.compare(
-                        ver1=version_num,
-                        oper='>=',
-                        ver2=cver,
-                        cmp_func=version_cmp):
-                    to_install.append(pkgstr)
-                else:
-                    if not kwargs.get('only_upgrade', False):
-                        to_downgrade.append(pkgstr)
-                    else:
-                        # This should cause the command to fail.
-                        to_install.append(pkgstr)
+                        pkgstr = '{0}={1}'.format(pkgname, version_num)
+                        if reinstall and cver and salt.utils.versions.compare(
+                                ver1=version_num,
+                                oper='==',
+                                ver2=cver,
+                                cmp_func=version_cmp):
+                            to_reinstall.append(pkgstr)
+                        elif not cver or salt.utils.versions.compare(
+                                ver1=version_num,
+                                oper='>=',
+                                ver2=cver,
+                                cmp_func=version_cmp):
+                            to_install.append(pkgstr)
+                        else:
+                            if not kwargs.get('only_upgrade', False):
+                                to_downgrade.append(pkgstr)
+                            else:
+                                # This should cause the command to fail.
+                                to_install.append(pkgstr)
 
     cmds = _build_install_command_list(cmd_prefix, to_install, to_downgrade, to_reinstall)
 

--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -532,7 +532,6 @@ def install(name=None,
                         # Version conditions are sent to the solver as install commands
                         pkgstr = '{0}{1}{2}'.format(pkgname, version_operator, version_string)
                         to_install.append(pkgstr)
-                        cmd_prefix.append('--force-downgrade')
                     else:
                         pkgstr = '{0}={1}'.format(pkgname, version_num)
                         if reinstall and cver and salt.utils.versions.compare(

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -263,8 +263,8 @@ def compare(ver1='', oper='==', ver2='', cmp_func=None, ignore_epoch=False):
     Compares two version numbers. Accepts a custom function to perform the
     cmp-style version comparison, otherwise uses version_cmp().
     '''
-    cmp_map = {'<': (-1,), '<=': (-1, 0), '==': (0,),
-               '>=': (0, 1), '>': (1,)}
+    cmp_map = {'<<': (-1,), '<': (-1,), '<=': (-1, 0), '==': (0,),
+               '>=': (0, 1), '>': (1,), '>>': (1,)}
     if oper not in ('!=',) and oper not in cmp_map:
         log.error('Invalid operator \'%s\' for version comparison', oper)
         return False


### PR DESCRIPTION
### What does this PR do?
Add support for operators in version. We can use >=, >>, <= << operators for package version.

### Previous Behavior
If we use those operators, it will fail saying that it couldn't find package with version "=>=20.5.0".

### New Behavior
It identify the operator and used it without adding "=" for this case.

