### PR TITLE
Enable iptables module on NILinuxRT systems

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -118,6 +118,11 @@ def _conf(family='ipv4'):
             return '/etc/iptables/rules6-save'
         else:
             return '/etc/iptables/rules-save'
+    elif __grains__['os_family'] == 'NILinuxRT':
+        if family == 'ipv6':
+            return '/etc/natinst/share/ip6tables.conf'
+        else:
+            return '/etc/natinst/share/iptables.conf'
     else:
         raise SaltException('Saving iptables to file is not' +
                             ' supported on {0}.'.format(__grains__['os']) +


### PR DESCRIPTION
Enable iptables module on NILinuxRT systems

Signed-off-by: Cristian Hotea <cristian.hotea@ni.com>
