### PR TITLE
Add event for refreshing the grains only

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2202,6 +2202,20 @@ class Minion(MinionBase):
         log.debug('Refreshing matchers.')
         self.matchers = salt.loader.matchers(self.opts)
 
+    def grains_only_refresh(self, force_refresh=False, notify=False):
+        '''
+        Refresh the grains
+        '''
+        # This might be a proxy minion
+        if hasattr(self, 'proxy'):
+            proxy = self.proxy
+        else:
+            proxy = None
+        self.opts['grains'] = salt.loader.grains(self.opts, force_refresh, proxy=proxy)
+        if notify:
+            evt = salt.utils.event.get_event('minion', opts=self.opts)
+            evt.fire_event({'complete': True}, tag='/salt/minion/minion_grains_refresh_complete')
+
     # TODO: only allow one future in flight at a time?
     @salt.ext.tornado.gen.coroutine
     def pillar_refresh(self, force_refresh=False):
@@ -2402,6 +2416,11 @@ class Minion(MinionBase):
             if (data.get('force_refresh', False) or
                     self.grains_cache != self.opts['grains']):
                 self.pillar_refresh(force_refresh=True)
+                self.grains_cache = self.opts['grains']
+        elif tag.startswith('grains_only_refresh'):
+            if (data.get('force_refresh', False) or
+                    self.grains_cache != self.opts['grains']):
+                self.grains_only_refresh(force_refresh=True, notify=data.get('notify', False))
                 self.grains_cache = self.opts['grains']
         elif tag.startswith('environ_setenv'):
             self.environ_setenv(tag, data)


### PR DESCRIPTION
There are use cases when we want to refresh only the grains
without refreshing the other modules. One example would be when
locking a system. We want to lock the system, then wait for grains
to get refreshed in order to prevent the execution of the next jobs
and avoid race conditions.

Signed-off-by: Cristian Hotea <cristian.hotea@ni.com>

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
