### PR TITLE
Fix upgraded packages not returning an old version when ran in test_mode

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -360,15 +360,20 @@ def _parse_reported_packages_from_install_output(output):
     We are looking for lines like:
         Installing <package> (<version>) on <target>
     or
-        Upgrading <package> from <oldVersion> to <version> on root
+        Upgrading <package> from <oldVersion> to <version> on <target>
+    or
+        Upgrading <oldPackage> (<oldVersion>) to <package> (<version>) on <target>
     '''
     reported_pkgs = {}
     install_pattern = re.compile(r'Installing\s(?P<package>.*?)\s\((?P<version>.*?)\)\son\s(?P<target>.*?)')
-    upgrade_pattern = re.compile(r'Upgrading\s(?P<package>.*?)\sfrom\s(?P<oldVersion>.*?)\sto\s(?P<version>.*?)\son\s(?P<target>.*?)')
+    internal_solver_upgrade_pattern = re.compile(r'Upgrading\s(?P<package>.*?)\sfrom\s(?P<oldVersion>.*?)\sto\s(?P<version>.*?)\son\s(?P<target>.*?)')
+    libsolv_solver_upgrade_pattern = re.compile(r'Upgrading\s(?P<oldPackage>.*?)\s\((?P<oldVersion>.*?)\)\sto\s(?P<package>.*?)\s\((?P<version>.*?)\)\son\s(?P<target>.*?)')
     for line in salt.utils.itertools.split(output, '\n'):
         match = install_pattern.match(line)
         if match is None:
-            match = upgrade_pattern.match(line)
+            match = internal_solver_upgrade_pattern.match(line)
+        if match is None:
+            match = libsolv_solver_upgrade_pattern.match(line)
         if match:
             reported_pkgs[match.group('package')] = match.group('version')
 


### PR DESCRIPTION
Signed-off-by: Raul Zavaczki <raul.zavaczki@ni.com>

### What does this PR do?
opkg seems to output upgrading packages in a new way (Installing has remained the same), and because of this the test_packages were not parsed correctly when ran in test_mode.
This PR adds a new check for the new output, but it does NOT remove the old check since in the sources of opkg the old message is still there - but I don't know and I am not sure how and if that code can be called.

### What issues does this PR fix or reference?
Parsing upgraded packages in test_mode
