### PR TITLE
Save the function index in the minion context

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1873,6 +1873,7 @@ class Minion(MinionBase):
         for ind in range(0, num_funcs):
             function_name = data['fun'][ind]
             function_args = data['arg'][ind]
+            minion_instance.functions.pack['__context__'][data['jid'] + "_function_index"] = ind
             if not multifunc_ordered:
                 ret['success'][function_name] = False
             try:
@@ -1913,6 +1914,7 @@ class Minion(MinionBase):
             ret['jid'] = data['jid']
             ret['fun'] = data['fun']
             ret['fun_args'] = data['arg']
+        minion_instance.functions.pack['__context__'].pop(data['jid'] + "_function_index", None)
         if 'metadata' in data:
             ret['metadata'] = data['metadata']
         if minion_instance.connected:


### PR DESCRIPTION
We need the index in the executor to determine when a job
gets started or is finished and notify the TrayApp
accordingly.

Signed-off-by: Cristian Hotea <cristian.hotea@ni.com>

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
