### PR TITLE
Fix errors and reportedPkgs not returned correctly when removing packages in test_mode

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -833,14 +833,13 @@ def _execute_remove_command(cmd, is_testmode, errors, reportedPkgs, jid):
     else:
         out = _call_opkg(cmd)
 
-    errors = []
     if out['retcode'] != 0:
         if out['stderr']:
-            errors = [out['stderr']]
+            errors.append(out['stderr'])
         else:
-            errors = [out['stdout']]
+            errors.append(out['stdout'])
     elif is_testmode:
-        reportedPkgs = _parse_reported_packages_from_remove_output(out['stdout'])
+        reportedPkgs.update(_parse_reported_packages_from_remove_output(out['stdout']))
 
 def remove(name=None, pkgs=None, **kwargs):  # pylint: disable=unused-argument
     '''


### PR DESCRIPTION
### What does this PR do?
Fix errors and reportedPkgs not returned correctly when removing packages in test_mode

### What issues does this PR fix or reference?
reportedPkgs and errors were not updated by the _execute_remove_command, so they were always empty, rendering in an invalid count in Summary.