### PR TITLE
Send progress events even if the current output is not valid

### DIFF
--- a/salt/modules/opkg.py
+++ b/salt/modules/opkg.py
@@ -491,14 +491,12 @@ def _process_with_progress(cmd, jid, total_packages_count):
                 output = proc.stdout.readline()
                 stdout += output
                 line_operation, line_package = _get_operation_and_package_from_output_line(output)
-                if not line_operation or not line_package:
-                    continue
-
-                operation = line_operation
-                current_package = line_package
-                if operation in ['install', 'upgrade', 'remove', 'downgrade']:
-                    processed_count += 1
-                    force_update |= processed_count in [1, total_packages_count]
+                if line_operation and line_package:
+                    operation = line_operation
+                    current_package = line_package
+                    if operation in ['install', 'upgrade', 'remove', 'downgrade']:
+                        processed_count += 1
+                        force_update |= processed_count in [1, total_packages_count]
             timestamp = time.time()
             if (timestamp - last_notify_timestamp > notify_progress_period or force_update) and \
                     last_sent_package != current_package:


### PR DESCRIPTION
The current behavior is that we get the package and operation from the current output - and if it's not valid we 'continue' the while-loop, and because of this, if the current line does NOT contain a valid package/operation we do NOT check if we should send a progress event to salt-master.

An example would be - with pkg_notify_progress as 15:
00:01 - Installing package A -- Event sent
00:14 - Installing package B -- Event not sent (13 < 15)
... Package B installs DKMS stuff for 1 minute ... -- UI shows we're still at package A, since we haven't updated

Signed-off-by: Raul Zavaczki <raul.zavaczki@ni.com>
