### PR TITLE
Add ni api key to messages sent from minion to the master

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -304,6 +304,7 @@ class AsyncTCPReqChannel(salt.transport.client.ReqChannel):
     def _package_load(self, load):
         return {
             'enc': self.crypt,
+            'x-ni-api-key': self.opts.get('x-ni-api-key'),
             'load': load,
         }
 
@@ -413,6 +414,7 @@ class AsyncTCPPubChannel(salt.transport.mixins.auth.AESPubClientMixin, salt.tran
     def _package_load(self, load):
         return {
             'enc': self.crypt,
+            'x-ni-api-key': self.opts.get('x-ni-api-key'),
             'load': load,
         }
 


### PR DESCRIPTION
### What does this PR do?
Sends the x-ni-api-key saved in the minion config to the master along with the messages. This helps in the cloud case so that we can support older minions as well when we'll have SystemsManagement in cloud.

