### PR TITLE
Fix memory leak when running refresh jobs

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1516,23 +1516,26 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                         self._reload_submodules(mod)
                 else:
                     if USE_IMPORTLIB:
-                        # pylint: disable=no-member
-                        loader = MODULE_KIND_MAP[desc[2]](mod_namespace, fpath)
-                        spec = importlib.util.spec_from_file_location(
-                            mod_namespace, fpath, loader=loader
-                        )
-                        if spec is None:
-                            raise ImportError()
-                        # TODO: Get rid of load_module in favor of
-                        # exec_module below. load_module is deprecated, but
-                        # loading using exec_module has been causing odd things
-                        # with the magic dunders we pack into the loaded
-                        # modules, most notably with salt-ssh's __opts__.
-                        mod = spec.loader.load_module()
-                        #mod = importlib.util.module_from_spec(spec)
-                        #spec.loader.exec_module(mod)
-                        # pylint: enable=no-member
-                        sys.modules[mod_namespace] = mod
+                        try:
+                            mod = sys.modules[mod_namespace]
+                        except KeyError:
+                            # pylint: disable=no-member
+                            loader = MODULE_KIND_MAP[desc[2]](mod_namespace, fpath)
+                            spec = importlib.util.spec_from_file_location(
+                                mod_namespace, fpath, loader=loader
+                            )
+                            if spec is None:
+                                raise ImportError()
+                            # TODO: Get rid of load_module in favor of
+                            # exec_module below. load_module is deprecated, but
+                            # loading using exec_module has been causing odd things
+                            # with the magic dunders we pack into the loaded
+                            # modules, most notably with salt-ssh's __opts__.
+                            mod = spec.loader.load_module()
+                            #mod = importlib.util.module_from_spec(spec)
+                            #spec.loader.exec_module(mod)
+                            # pylint: enable=no-member
+                            sys.modules[mod_namespace] = mod
                     else:
                         with salt.utils.files.fopen(fpath, desc[1]) as fn_:
                             mod = imp.load_module(mod_namespace, fn_, fpath, desc)

--- a/salt/transport/client.py
+++ b/salt/transport/client.py
@@ -78,7 +78,7 @@ class AsyncChannel(object):
     _resolver_configured = False
 
     @classmethod
-    def _config_resolver(cls, num_threads=10):
+    def _config_resolver(cls, num_threads=1):
         from tornado.netutil import Resolver
         Resolver.configure(
                 'tornado.netutil.ThreadedResolver',


### PR DESCRIPTION
### What does this PR do?
- do not create a new thread for each job. use a thread pool instead. This is because python leaks memory when continously creating threads and joining them.
- do not reload python modules if they are already loaded.
- do not use 10 threads for resolving the ip address of the master

### What issues does this PR fix or reference?
Fixes: 
 - memory leak where after some refresh jobs the memory increased by approx ~3MB.

### Previous Behavior
 - after running enough refresh jobs on the minion, jobs failed with "Cannot allocate memory" (depending on the available memory on the minion)

### New Behavior
 - ran refresh jobs for 2 days continously and used memory remained steady.
