### PR TITLE
Handle exceptions thrown while trying to publish presence events

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -1318,12 +1318,16 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer, object):
     @salt.ext.tornado.gen.coroutine
     def _send_presence_events(self):
         while True:
-            data = {'present': list(self.present.keys())}
-            self.event.fire_event(
-                data,
-                salt.utils.event.tagify('present', 'presence')
-            )
-            yield salt.ext.tornado.gen.sleep(60)
+            try:
+                data = {'present': list(self.present.keys())}
+                self.event.fire_event(
+                    data,
+                    salt.utils.event.tagify('present', 'presence')
+                )
+                yield salt.ext.tornado.gen.sleep(60)
+            except Exception as exc:
+                log.warning('Could not publish presence event: %s', str(exc))
+                yield salt.ext.tornado.gen.sleep(2)
 
     def _add_client_present(self, client):
         id_ = client.id_


### PR DESCRIPTION
### What does this PR do?
Handles exceptions that are thrown while trying to publish presence events

### What issues does this PR fix or reference?
N/A

### Previous Behavior
When during the publishing of presence events an exception was thrown, the loop that published presence events stopped and therefore no more presence events were sent until the salt master was restarted

### New Behavior
When during the publishing of presence events an exception is thrown, the exception is logged and the loop continue to publish presence events.