### PR TITLE
Fix restartcheck.py

### DIFF
--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -379,9 +379,6 @@ def _file_changed_nilrt(full_filepath):
     # Need timestamp in seconds so floor it using int()
     cur_timestamp = str(int(os.path.getmtime(full_filepath)))
 
-    print("PREV TIMESTAMP " + str(prev_timestamp))
-    print("CUR TIMESTAMP " + str(cur_timestamp))
-
     if prev_timestamp != cur_timestamp:
         return True
 
@@ -416,8 +413,6 @@ def _sysapi_changed_nilrt():
              - False if no nisysapi .ini files exist
     '''
     nisysapi_path = '/usr/local/natinst/share/nisysapi.ini'
-    print("OS PATH EXISTS : " + str(os.path.exists(nisysapi_path)))
-    print("FILE CHANGED NILRT : " + str(_file_changed_nilrt(nisysapi_path)))
     if os.path.exists(nisysapi_path) and _file_changed_nilrt(nisysapi_path):
         return True
 
@@ -498,9 +493,6 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
             if __grains__.get('os_family') == NILRT_FAMILY_NAME:
                 # Check kernel modules and hardware API's for version changes
                 # If a restartcheck=True event was previously witnessed, propagate it
-                print("Kernel modules changed " + str(_kernel_modules_changed_nilrt(kernel)))
-                print("Sysapi changed " + str(_sysapi_changed_nilrt()))
-                print("salt changed " + str(__salt__['system.get_reboot_required_witnessed']()))
                 if not _kernel_modules_changed_nilrt(kernel) and \
                    not _sysapi_changed_nilrt() and \
                    not __salt__['system.get_reboot_required_witnessed']():
@@ -540,9 +532,7 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
                 running_services[service] = int(service_show['ExecMainPID'])
 
     owners_cache = {}
-    print("WOW!")
     for deleted_file in _deleted_files():
-        print(str(deleted_file))
         if deleted_file is False:
             return {'result': False, 'comment': 'Could not get list of processes.'
                                                 ' (Do you have root access?)'}
@@ -579,8 +569,6 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
                 if program not in packages[packagename]['processes']:
                     packages[packagename]['processes'].append(program)
 
-    print("WOW2")
-    print(str(kernel_restart))
     if not packages and not kernel_restart:
         return 'No packages seem to need to be restarted.'
 

--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -379,10 +379,13 @@ def _file_changed_nilrt(full_filepath):
     # Need timestamp in seconds so floor it using int()
     cur_timestamp = str(int(os.path.getmtime(full_filepath)))
 
+    print("PREV TIMESTAMP " + str(prev_timestamp))
+    print("CUR TIMESTAMP " + str(cur_timestamp))
+
     if prev_timestamp != cur_timestamp:
         return True
 
-    return bool(__salt__['cmd.retcode']('md5sum -cs {0}'.format(md5sum_file), output_loglevel="quiet"))
+    return bool(__salt__['cmd.retcode']('md5sum -c {0} --quiet'.format(md5sum_file), output_loglevel="quiet"))
 
 
 def _kernel_modules_changed_nilrt(kernelversion):
@@ -413,6 +416,8 @@ def _sysapi_changed_nilrt():
              - False if no nisysapi .ini files exist
     '''
     nisysapi_path = '/usr/local/natinst/share/nisysapi.ini'
+    print("OS PATH EXISTS : " + str(os.path.exists(nisysapi_path)))
+    print("FILE CHANGED NILRT : " + str(_file_changed_nilrt(nisysapi_path)))
     if os.path.exists(nisysapi_path) and _file_changed_nilrt(nisysapi_path):
         return True
 
@@ -490,9 +495,12 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
     for kernel in kernel_versions:
         _check_timeout(start_time, timeout)
         if kernel in kernel_current:
-            if __grains__.get('os_family') == 'NILinuxRT':
+            if __grains__.get('os_family') == NILRT_FAMILY_NAME:
                 # Check kernel modules and hardware API's for version changes
                 # If a restartcheck=True event was previously witnessed, propagate it
+                print("Kernel modules changed " + str(_kernel_modules_changed_nilrt(kernel)))
+                print("Sysapi changed " + str(_sysapi_changed_nilrt()))
+                print("salt changed " + str(__salt__['system.get_reboot_required_witnessed']()))
                 if not _kernel_modules_changed_nilrt(kernel) and \
                    not _sysapi_changed_nilrt() and \
                    not __salt__['system.get_reboot_required_witnessed']():
@@ -524,14 +532,17 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
     else:
         excludepid = []
 
-    for service in __salt__['service.get_running']():
-        _check_timeout(start_time, timeout)
-        service_show = __salt__['service.show'](service)
-        if 'ExecMainPID' in service_show:
-            running_services[service] = int(service_show['ExecMainPID'])
+    if __grains__.get('os_family') != NILRT_FAMILY_NAME:
+        for service in __salt__['service.get_running']():
+            _check_timeout(start_time, timeout)
+            service_show = __salt__['service.show'](service)
+            if 'ExecMainPID' in service_show:
+                running_services[service] = int(service_show['ExecMainPID'])
 
     owners_cache = {}
+    print("WOW!")
     for deleted_file in _deleted_files():
+        print(str(deleted_file))
         if deleted_file is False:
             return {'result': False, 'comment': 'Could not get list of processes.'
                                                 ' (Do you have root access?)'}
@@ -552,12 +563,13 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
             if not packagename:
                 packagename = name
             owners_cache[readlink] = packagename
-        for running_service in running_services:
-            _check_timeout(start_time, timeout)
-            if running_service not in restart_services and pid == running_services[running_service]:
-                if packagename and packagename not in ignorelist:
-                    restart_services.append(running_service)
-                    name = running_service
+        if __grains__.get('os_family') != NILRT_FAMILY_NAME:
+            for running_service in running_services:
+                _check_timeout(start_time, timeout)
+                if running_service not in restart_services and pid == running_services[running_service]:
+                    if packagename and packagename not in ignorelist:
+                        restart_services.append(running_service)
+                        name = running_service
         if packagename and packagename not in ignorelist:
             program = '\t' + six.text_type(pid) + ' ' + readlink + ' (file: ' + six.text_type(path) + ')'
             if packagename not in packages:
@@ -567,6 +579,8 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
                 if program not in packages[packagename]['processes']:
                     packages[packagename]['processes'].append(program)
 
+    print("WOW2")
+    print(str(kernel_restart))
     if not packages and not kernel_restart:
         return 'No packages seem to need to be restarted.'
 
@@ -635,12 +649,13 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
             restartservicecommands.extend(['systemctl restart ' + s for s in packages[package]['systemdservice']])
         else:
             nonrestartable.append(package)
-        if packages[package]['process_name'] in restart_services:
+        if __grains__.get('os_family') != NILRT_FAMILY_NAME and packages[package]['process_name'] in restart_services:
             restart_services.remove(packages[package]['process_name'])
 
-    for restart_service in restart_services:
-        _check_timeout(start_time, timeout)
-        restartservicecommands.extend(['systemctl restart ' + restart_service])
+    if __grains__.get('os_family') != NILRT_FAMILY_NAME:
+        for restart_service in restart_services:
+            _check_timeout(start_time, timeout)
+            restartservicecommands.extend(['systemctl restart ' + restart_service])
 
     ret = _format_output(kernel_restart, packages, verbose, restartable, nonrestartable,
                          restartservicecommands, restartinitcommands)


### PR DESCRIPTION
### What does this PR do?
Some upstream commits had the effect of breaking restartcheck on NILinuxRT targets, due to the assumptions that we have a `service.get_running` virtual method.
This PR safe-guards NILinuxRT against the problematic code.

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
