### PR TITLE
Add 2 second timeout on DNS socket check

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1898,6 +1898,7 @@ def _test_addrs(addrinfo, port):
 
         try:
             s = socket.socket(ip_family, socket.SOCK_STREAM)
+            s.settimeout(2)
             s.connect((ip_addr, port))
             s.close()
 

--- a/tests/unit/utils/test_network.py
+++ b/tests/unit/utils/test_network.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals, print_function
 import logging
 import socket
 import textwrap
+import time
 
 # Import Salt Testing libs
 from tests.support.unit import TestCase
@@ -334,6 +335,12 @@ class NetworkTestCase(TestCase):
             addrs = network._test_addrs(addrinfo, 80)
             self.assertTrue(len(addrs) == 1)
             self.assertTrue(addrs[0] == addrinfo[2][4][0])
+
+            # attempt to connect to resolved address with default timeout
+            s.side_effect = socket.error
+            addrs = network._test_addrs(addrinfo, 80)
+            time.sleep(2)
+            self.assertFalse(len(addrs) == 0)
 
             # nothing can connect, but we've eliminated duplicates
             s.side_effect = socket.error


### PR DESCRIPTION
### What does this PR do?
Cherry-pick the upstream fix for salt taking too long resolving DNS's from master.conf

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
