### PR TITLE
Attempt connection on same ip when it is lost

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -743,12 +743,12 @@ class MinionBase(object):
                     yield salt.ext.tornado.gen.sleep(opts['acceptance_wait_time'])
                 attempts += 1
                 if tries > 0:
-                    log.error(
+                    log.debug(
                         'Connecting to master. Attempt %s of %s',
                         attempts, tries
                     )
                 else:
-                    log.error(
+                    log.debug(
                         'Connecting to master. Attempt %s (infinite attempts)',
                         attempts
                     )


### PR DESCRIPTION
### What does this PR do?
When the connection to the salt master, attempt 3 times to reconnect to the same ip. If the connection still can't be established, fall back to the previous approach, where the salt minion looks for another ip address to connect to. This fixes an issue with #47, that when the master disconnects and the master is specified through a host, the ip is resolved to a different one (ipv6) and doesn't change until the retries to send the message through tcp have finished, so they can't evet succeed. Attempting to connect to the same ip will let those retries to succeed if the master comes back live.

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
