### PR TITLE
Fix collections.Mapping

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -226,7 +226,7 @@ def setvals(grains, destructive=False):
         salt '*' grains.setvals "{'key1': 'val1', 'key2': 'val2'}"
     '''
     new_grains = grains
-    if not isinstance(new_grains, collections.Mapping):
+    if not isinstance(new_grains, collections.abc.Mapping):
         raise SaltException('setvals grains must be a dictionary.')
     grains = {}
     if os.path.isfile(__opts__['conf_file']):


### PR DESCRIPTION
`collections.Mapping` is deprecated since Python 3.3 and removed in Python 3.10. Therefore, if Python is upgraded to 3.10, this breaks. Changing it to `collections.abc.Mapping`. Tested and it works with salt on Python 3.10