### PR TITLE
Default crypto library to `pycryptodomex`

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -473,16 +473,22 @@ def _runtests(session, coverage, cmd_args):
 @nox.session(python=_PYTHON_VERSIONS, name='runtests-parametrized')
 @nox.parametrize('coverage', [False, True])
 @nox.parametrize('transport', ['zeromq', 'tcp'])
-@nox.parametrize('crypto', [None, 'm2crypto', 'pycryptodomex'])
+@nox.parametrize('crypto', [None, 'm2crypto', 'pycryptodome'])
 def runtests_parametrized(session, coverage, transport, crypto):
     # Install requirements
     _install_requirements(session, transport, 'unittest-xml-reporting==2.5.2')
 
     if crypto:
-        if crypto == 'm2crypto':
-            session.run('pip', 'uninstall', '-y', 'pycrypto', 'pycryptodome', 'pycryptodomex', silent=True)
-        else:
-            session.run('pip', 'uninstall', '-y', 'm2crypto', silent=True)
+        session.run(
+            "pip",
+            "uninstall",
+            "-y",
+            "m2crypto",
+            "pycrypto",
+            "pycryptodome",
+            "pycryptodomex",
+            silent=True,
+        )
         distro_constraints = _get_distro_pip_constraints(session, transport)
         install_command = [
             '--progress-bar=off',
@@ -585,42 +591,42 @@ def runtests_zeromq_m2crypto(session, coverage):
     )
 
 
-@nox.session(python=_PYTHON_VERSIONS, name='runtests-pycryptodomex')
+@nox.session(python=_PYTHON_VERSIONS, name='runtests-pycryptodome')
 @nox.parametrize('coverage', [False, True])
-def runtests_pycryptodomex(session, coverage):
+def runtests_pycryptodome(session, coverage):
     '''
-    runtests.py session with zeromq transport and pycryptodomex
+    runtests.py session with zeromq transport and pycryptodome
     '''
     session.notify(
-        'runtests-parametrized-{}(coverage={}, crypto=\'pycryptodomex\', transport=\'zeromq\')'.format(
+        'runtests-parametrized-{}(coverage={}, crypto=\'pycryptodome\', transport=\'zeromq\')'.format(
             session.python,
             coverage
         )
     )
 
 
-@nox.session(python=_PYTHON_VERSIONS, name='runtests-tcp-pycryptodomex')
+@nox.session(python=_PYTHON_VERSIONS, name='runtests-tcp-pycryptodome')
 @nox.parametrize('coverage', [False, True])
-def runtests_tcp_pycryptodomex(session, coverage):
+def runtests_tcp_pycryptodome(session, coverage):
     '''
-    runtests.py session with TCP transport and pycryptodomex
+    runtests.py session with TCP transport and pycryptodome
     '''
     session.notify(
-        'runtests-parametrized-{}(coverage={}, crypto=\'pycryptodomex\', transport=\'tcp\')'.format(
+        'runtests-parametrized-{}(coverage={}, crypto=\'pycryptodome\', transport=\'tcp\')'.format(
             session.python,
             coverage
         )
     )
 
 
-@nox.session(python=_PYTHON_VERSIONS, name='runtests-zeromq-pycryptodomex')
+@nox.session(python=_PYTHON_VERSIONS, name='runtests-zeromq-pycryptodome')
 @nox.parametrize('coverage', [False, True])
-def runtests_zeromq_pycryptodomex(session, coverage):
+def runtests_zeromq_pycryptodome(session, coverage):
     '''
-    runtests.py session with zeromq transport and pycryptodomex
+    runtests.py session with zeromq transport and pycryptodome
     '''
     session.notify(
-        'runtests-parametrized-{}(coverage={}, crypto=\'pycryptodomex\', transport=\'zeromq\')'.format(
+        'runtests-parametrized-{}(coverage={}, crypto=\'pycryptodome\', transport=\'zeromq\')'.format(
             session.python,
             coverage
         )
@@ -662,16 +668,22 @@ def runtests_tornado(session, coverage):
 @nox.session(python=_PYTHON_VERSIONS, name='pytest-parametrized')
 @nox.parametrize('coverage', [False, True])
 @nox.parametrize('transport', ['zeromq', 'tcp'])
-@nox.parametrize('crypto', [None, 'm2crypto', 'pycryptodomex'])
+@nox.parametrize('crypto', [None, 'm2crypto', 'pycryptodome'])
 def pytest_parametrized(session, coverage, transport, crypto):
     # Install requirements
     _install_requirements(session, transport)
 
     if crypto:
-        if crypto == 'm2crypto':
-            session.run('pip', 'uninstall', '-y', 'pycrypto', 'pycryptodome', 'pycryptodomex', silent=True)
-        else:
-            session.run('pip', 'uninstall', '-y', 'm2crypto', silent=True)
+        session.run(
+            "pip",
+            "uninstall",
+            "-y",
+            "m2crypto",
+            "pycrypto",
+            "pycryptodome",
+            "pycryptodomex",
+            silent=True,
+        )
         distro_constraints = _get_distro_pip_constraints(session, transport)
         install_command = [
             '--progress-bar=off',
@@ -779,42 +791,42 @@ def pytest_zeromq_m2crypto(session, coverage):
     )
 
 
-@nox.session(python=_PYTHON_VERSIONS, name='pytest-pycryptodomex')
+@nox.session(python=_PYTHON_VERSIONS, name='pytest-pycryptodome')
 @nox.parametrize('coverage', [False, True])
-def pytest_pycryptodomex(session, coverage):
+def pytest_pycryptodome(session, coverage):
     '''
-    pytest session with zeromq transport and pycryptodomex
+    pytest session with zeromq transport and pycryptodome
     '''
     session.notify(
-        'pytest-parametrized-{}(coverage={}, crypto=\'pycryptodomex\', transport=\'zeromq\')'.format(
+        'pytest-parametrized-{}(coverage={}, crypto=\'pycryptodome\', transport=\'zeromq\')'.format(
             session.python,
             coverage
         )
     )
 
 
-@nox.session(python=_PYTHON_VERSIONS, name='pytest-tcp-pycryptodomex')
+@nox.session(python=_PYTHON_VERSIONS, name='pytest-tcp-pycryptodome')
 @nox.parametrize('coverage', [False, True])
-def pytest_tcp_pycryptodomex(session, coverage):
+def pytest_tcp_pycryptodome(session, coverage):
     '''
-    pytest session with TCP transport and pycryptodomex
+    pytest session with TCP transport and pycryptodome
     '''
     session.notify(
-        'pytest-parametrized-{}(coverage={}, crypto=\'pycryptodomex\', transport=\'tcp\')'.format(
+        'pytest-parametrized-{}(coverage={}, crypto=\'pycryptodome\', transport=\'tcp\')'.format(
             session.python,
             coverage
         )
     )
 
 
-@nox.session(python=_PYTHON_VERSIONS, name='pytest-zeromq-pycryptodomex')
+@nox.session(python=_PYTHON_VERSIONS, name='pytest-zeromq-pycryptodome')
 @nox.parametrize('coverage', [False, True])
-def pytest_zeromq_pycryptodomex(session, coverage):
+def pytest_zeromq_pycryptodome(session, coverage):
     '''
-    pytest session with zeromq transport and pycryptodomex
+    pytest session with zeromq transport and pycryptodome
     '''
     session.notify(
-        'pytest-parametrized-{}(coverage={}, crypto=\'pycryptodomex\', transport=\'zeromq\')'.format(
+        'pytest-parametrized-{}(coverage={}, crypto=\'pycryptodome\', transport=\'zeromq\')'.format(
             session.python,
             coverage
         )

--- a/pkg/osx/req.txt
+++ b/pkg/osx/req.txt
@@ -19,7 +19,7 @@ msgpack==1.0.0
 psutil==5.6.1
 pyasn1==0.4.5
 pycparser==2.19
-pycryptodome==3.8.1
+pycryptodomex==3.9.7
 python-dateutil==2.8.0
 python-gnupg==0.4.4
 pyyaml==5.1.2

--- a/pkg/windows/req.txt
+++ b/pkg/windows/req.txt
@@ -19,7 +19,7 @@ msgpack-python==0.5.6
 psutil==5.6.1
 pyasn1==0.4.5
 pycparser==2.19
-pycryptodomex==3.8.1
+pycryptodomex==3.9.7
 pycurl==7.43.0.2
 pymssql==2.1.4
 PyMySQL==0.9.3

--- a/requirements/static/py3.5/darwin-crypto.txt
+++ b/requirements/static/py3.5/darwin-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.5/darwin-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.0
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.5/linux-crypto.txt
+++ b/requirements/static/py3.5/linux-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.5/linux-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.3
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.5/windows-crypto.txt
+++ b/requirements/static/py3.5/windows-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.5/windows-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.0
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.5/windows.txt
+++ b/requirements/static/py3.5/windows.txt
@@ -69,7 +69,7 @@ pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5
 pycparser==2.19
 pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.8.1 ; sys_platform == "win32"
+pycryptodomex==3.9.7
 pycurl==7.43.0.2
 pygit2==0.28.2
 pymssql==2.1.4

--- a/requirements/static/py3.6/darwin-crypto.txt
+++ b/requirements/static/py3.6/darwin-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.6/darwin-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.0
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.6/linux-crypto.txt
+++ b/requirements/static/py3.6/linux-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.6/linux-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.3
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.6/windows-crypto.txt
+++ b/requirements/static/py3.6/windows-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.6/windows-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.0
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.6/windows.txt
+++ b/requirements/static/py3.6/windows.txt
@@ -68,7 +68,7 @@ pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5
 pycparser==2.19
 pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.8.1 ; sys_platform == "win32"
+pycryptodomex==3.9.7
 pycurl==7.43.0.2
 pygit2==0.28.2
 pymssql==2.1.4

--- a/requirements/static/py3.7/darwin-crypto.txt
+++ b/requirements/static/py3.7/darwin-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.7/darwin-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.0
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.7/linux-crypto.txt
+++ b/requirements/static/py3.7/linux-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.7/linux-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.3
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.7/windows-crypto.txt
+++ b/requirements/static/py3.7/windows-crypto.txt
@@ -5,5 +5,5 @@
 #    pip-compile -o requirements/static/py3.7/windows-crypto.txt -v requirements/static/crypto.in
 #
 m2crypto==0.35.2
-pycryptodomex==3.9.0
+pycryptodome==3.9.7
 typing==3.7.4.1           # via m2crypto

--- a/requirements/static/py3.7/windows.txt
+++ b/requirements/static/py3.7/windows.txt
@@ -68,7 +68,7 @@ pyasn1-modules==0.2.4     # via google-auth
 pyasn1==0.4.5
 pycparser==2.19
 pycryptodome==3.8.1       # via python-jose
-pycryptodomex==3.8.1 ; sys_platform == "win32"
+pycryptodomex==3.9.7
 pycurl==7.43.0.2
 pygit2==0.28.2
 pymssql==2.1.4


### PR DESCRIPTION
Cherry pick [this commit](https://github.com/saltstack/salt/pull/56625/commits/a24f6fe7e7fbc2bbd3df6833e1b8d1f9e64afd6b) from [this PR](https://github.com/saltstack/salt/pull/56625), in order to remove dependencies to the unmaintained pycrypto library, which isn't working with openssl 3.0