### PR TITLE
Switch pycrypto to pycryptodome

### DIFF
--- a/requirements/crypto.txt
+++ b/requirements/crypto.txt
@@ -1,2 +1,2 @@
-pycrypto>=2.6.1; sys.platform not in 'win32,darwin'
+pycryptodome>=3.8.1; sys.platform not in 'win32,darwin'
 pycryptodomex; sys.platform == 'win32'


### PR DESCRIPTION
`pycrypto` is unmaintained and doesn't work with openssl 3.0. changing the requirement to `pycryptodome`, which is maintained and supports it.