### PR TITLE
Fix linux_distribution warning

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -66,7 +66,14 @@ try:
 
 
 except ImportError:
-    from distro import linux_distribution
+    import distro
+
+    def linux_distribution():
+        return (
+            distro.id(),
+            distro.version(best=True),
+            distro.codename(),
+        )
 
 # Import salt libs
 import salt.exceptions


### PR DESCRIPTION
distro.linux_distribution is deprecated and produces a warning:

```
[WARNING ][29218] /usr/lib/python3.10/site-packages/salt/grains/core.py:1957: DeprecationWarning: distro.linux_distribution() is deprecated. It should only be used as a compatibility shim with Python's platform.linux_distribution(). Please use distro.id(), distro.version() and distro.name() instead.
  x.strip('"').strip("'") for x in linux_distribution()
```

Changed to use distro.id(), distro.version() and distro.name()