### PR TITLE
Switch from distutils to setuptools

### DIFF
--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -339,8 +339,8 @@ def get_site_packages(venv):
 
     ret = __salt__['cmd.exec_code_all'](
         bin_path,
-        'from distutils import sysconfig; '
-            'print(sysconfig.get_python_lib())'
+        'import sysconfig; '
+            'print(sysconfig.get_path("purelib"))'
     )
 
     if ret['retcode'] != 0:

--- a/salt/utils/pkg/win.py
+++ b/salt/utils/pkg/win.py
@@ -82,10 +82,7 @@ try:
 except ImportError:
     from collections import OrderedDict
 
-try:
-    from salt.utils.versions import LooseVersion
-except ImportError:
-    from distutils.version import LooseVersion  # pylint: disable=blacklisted-module
+from salt.utils.versions import LooseVersion
 
 
 # pylint: disable=too-many-instance-attributes

--- a/salt/utils/versions.py
+++ b/salt/utils/versions.py
@@ -21,8 +21,16 @@ import datetime
 import inspect
 import contextlib
 # pylint: disable=blacklisted-module,no-name-in-module
-from distutils.version import StrictVersion as _StrictVersion
-from distutils.version import LooseVersion as _LooseVersion
+try:
+    from setuptools.distutils.version import LooseVersion as _LooseVersion
+    from setuptools.distutils.version import StrictVersion as _StrictVersion
+except ImportError:
+    try:
+        from setuptools._distutils.version import LooseVersion as _LooseVersion
+        from setuptools._distutils.version import StrictVersion as _StrictVersion
+    except ImportError:
+        from distutils.version import LooseVersion as _LooseVersion
+        from distutils.version import StrictVersion as _StrictVersion
 # pylint: enable=blacklisted-module,no-name-in-module
 
 # Import Salt libs


### PR DESCRIPTION
distutils is deprecated:
```
/usr/lib/python3.10/site-packages/salt/utils/versions.py:24: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
  from distutils.version import StrictVersion as _StrictVersion
```

Switching to setuptools