### PR TITLE
Change config_parser.readfp to read_file

### DIFF
--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -273,7 +273,7 @@ def _load_config(section, options, default_value='', filename=INI_FILE):
         return results
     with salt.utils.files.fopen(filename, 'r') as config_file:
         config_parser = configparser.RawConfigParser(dict_type=CaseInsensitiveDict)
-        config_parser.readfp(config_file)
+        config_parser.read_file(config_file)
         for option in options:
             results[option] = _remove_quotes(config_parser.get(section, option)) \
                 if config_parser.has_option(section, option) else default_value

--- a/salt/modules/nilrt_ip.py
+++ b/salt/modules/nilrt_ip.py
@@ -805,7 +805,7 @@ def _configure_static_interface(interface, **settings):
     if os.path.exists(INTERFACES_CONFIG):
         try:
             with salt.utils.files.fopen(INTERFACES_CONFIG, 'r') as config_file:
-                parser.readfp(config_file)
+                parser.read_file(config_file)
         except configparser.MissingSectionHeaderError:
             pass
     hwaddr = interface.hwaddr[:-1]


### PR DESCRIPTION
readfp has been replaced with read_file. [See the docs](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file)

This fixes the following warning:
```
[WARNING ] /usr/lib/python3.10/site-packages/salt/modules/nilrt_ip.py:276: DeprecationWarning: This method will be removed in Python 3.12. Use 'parser.read_file()' instead.
  config_parser.readfp(config_file)

```