### PR TITLE
Change currentThread to current_thread

### DIFF
--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -64,7 +64,7 @@ def _read_proc_file(path, opts):
     Return a dict of JID metadata, or None
     '''
     serial = salt.payload.Serial(opts)
-    current_thread = threading.currentThread().name
+    current_thread = threading.current_thread().name
     pid = os.getpid()
     with salt.utils.files.fopen(path, 'rb') as fp_:
         buf = fp_.read()


### PR DESCRIPTION
`currentThread` is deprecated in favor of `current_thread`

```
[WARNING ] /usr/lib/python3.10/site-packages/salt/utils/minion.py:67: DeprecationWarning: currentThread() is deprecated, use current_thread() instead
  current_thread = threading.currentThread().name
```