### PR TITLE
Change log to debug when conencting to the same master

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -679,7 +679,7 @@ class MinionBase(object):
                         opts.update(prep_ip_port(opts))
                         opts.update(resolve_dns(opts))
                     else:
-                        log.warn(
+                        log.debug(
                             'Connecting to the same master ip. Attempt %s of 3',
                             attempts
                         )


### PR DESCRIPTION
We need this to avoid polutting the log file when older SL Client app is running on the client. The newer versions are not using salt-call to get the connection status anymore

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?
**[NOTICE] Bug fixes or features added to Salt require tests.**
Please review the [test documentation](https://docs.saltstack.com/en/latest/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite.

Yes/No

### Commits signed with GPG?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
