### PR TITLE
Log info instead of error when looking for api key in file client logs

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -1048,17 +1048,17 @@ class RemoteClient(Client):
     def __get_api_key(self):
         pillar = self.opts.get('pillar')
         if pillar is None:
-            log.error("Error in file client when retrieving api key. No pillar was found.")
+            log.info("Error in file client when retrieving api key. No pillar was found.")
             return ''
         
         http = pillar.get('http')
         if http is None:
-            log.error("Error in file client when retrieving api key. No http credentials were found in the pillar.")
+            log.info("Error in file client when retrieving api key. No http credentials were found in the pillar.")
             return ''
         
         api_key = http.get('api_key')
         if api_key is None:
-            log.error("Error in file client when retrieving api key. No api key was found in the pillar's http credentials.")
+            log.info("Error in file client when retrieving api key. No api key was found in the pillar's http credentials.")
             return ''
         
         return api_key


### PR DESCRIPTION
The log will always error for files that need to be served that don't require authentication. Changing the log level to info in order to avoid creating false positives.