### PR TITLE
modules/restartcheck: Fix initscript identification

### DIFF
--- a/salt/modules/restartcheck.py
+++ b/salt/modules/restartcheck.py
@@ -543,6 +543,7 @@ def restartcheck(ignorelist=None, blacklist=None, excludepid=None, **kwargs):
             continue
         try:
             readlink = os.readlink('/proc/{0}/exe'.format(pid))
+            readlink = readlink.replace(' (deleted)', '')
         except OSError:
             excludepid.append(pid)
             continue


### PR DESCRIPTION
### What does this PR do?

When a running process' executable is replaced, restartcheck output shows following errors

"""
[ERROR   ] Command 'opkg' failed with return code: 255
[ERROR   ] stderr:  * opkg_search_cmd: no path found matching pattern '<process path> (deleted)'
[ERROR   ] retcode: 255
"""

Also, the correct initscript to restart the service is not identified in cases where the initscript that spawned the process has a different name than the process. And so the process appears after the following output

"""
These processes <N> do not seem to have an associated init script to restart them:
"""

This is due to /proc/*/exe containing the suffix ' (deleted)'.

Remove the suffix to fix these issues.

### New Behavior
ERRORs no longer present in output and initscript of process is correctly identified.