### PR TITLE
Relax constraints to accomodate what we have available on LinuxRT

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,14 +1,18 @@
 --constraint=constraints.txt
 
 Jinja2>=3.1.5
-jmespath
+# We don't use this, and we don't have a package available for it on RT
+#jmespath 
 msgpack>=1.0.0
 PyYAML
 MarkupSafe
 requests<2.32.0 ; python_version < '3.10'
 requests>=2.32.3 ; python_version >= '3.10'
 certifi==2023.07.22; python_version < '3.10'
-certifi>=2024.7.4; python_version >= '3.10'
+# Allowing older version for certifi since we don't have >=2024.7.4 available on RT.
+# Salt was using version 2023 before upgrading to 2024.7.4.
+#certifi>=2024.7.4; python_version >= '3.10'
+certifi>=2024.2.2; python_version >= '3.10'
 distro>=1.0.1
 psutil<6.0.0; python_version <= '3.9'
 psutil>=5.0.0; python_version >= '3.10'
@@ -18,4 +22,6 @@ croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
 # We need contextvars for salt-ssh
 contextvars
 cryptography>=42.0.0
-urllib3>=1.26.20,<2.0.0
+# Allowing newer urllib3 since newer salt versions have upgraded to >=2.0.0 without making modifications to the source code.
+# urllib3>=1.26.20,<2.0.0
+urllib3>=1.26.20


### PR DESCRIPTION
This PR relaxes some of the requirement constraints that salt has in order to accomodate the pacakges that we have available on LinuxRT:
- remove `jmespath` as this is only used to allow a json_query JINJA filter; this dependency was not installed on our previous salt 3000.2, so we have historically not used this filter anyway
- allow urllib3 version 2 as this is what RT ships and we cannot use 1.x. Newer salt versions have upgraded to urllib3 2.x without altering the source code, so using v2 is safe.
- allow an older (2024.4.2) certifi version as we don't have >=2024.7.8 available on RT. Salt had been using 2023.x before upgrading the requirement to at least 2024.7.8.