### PR TITLE
Remove contextvars dependency and require pycryptodome on Linux instead of pycryptodomex

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ requests>=2.32.3 ; python_version >= '3.10'
 certifi==2023.07.22; python_version < '3.10'
 # NI: Allowing older version for certifi since we don't have >=2024.7.4 available on RT;
 # salt was using version 2023 before upgrading to 2024.7.4.
-# certifi>=2024.7.4; python_version >= '3.10'
+#certifi>=2024.7.4; python_version >= '3.10'
 certifi>=2024.2.2; python_version >= '3.10'
 distro>=1.0.1
 psutil<6.0.0; python_version <= '3.9'
@@ -21,12 +21,12 @@ looseversion
 
 # NI: Remove croniter as a dependency as this significantly increases the LinuxRT image size, and is used for chron jobs,
 # which we have not supported out of the box for salt 3000.2 either, as we did not install this dep previously.
-# croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
+#croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
 
 # NI: We're removing this as a dependency because contextvars is available in the stdlib for Python >= 3.7.
 # We need contextvars for salt-ssh
 # contextvars
 cryptography>=42.0.0
 # NI: Allowing newer urllib3 since newer salt versions have upgraded to >=2.0.0 without making modifications to the source code.
-# urllib3>=1.26.20,<2.0.0
+#urllib3>=1.26.20,<2.0.0
 urllib3>=1.26.20

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -18,7 +18,11 @@ psutil<6.0.0; python_version <= '3.9'
 psutil>=5.0.0; python_version >= '3.10'
 packaging>=21.3
 looseversion
-croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
+
+# Remove croniter as a dependency as this significantly increases the LinuxRT image size, and is used for chron jobs,
+# which we have not supported out of the box for salt 3000.2 either, as we did not install this dep previously.
+# croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
+
 # We need contextvars for salt-ssh
 contextvars
 cryptography>=42.0.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 --constraint=constraints.txt
 
 Jinja2>=3.1.5
-# We don't use this, and we don't have a package available for it on RT
+# NI: We don't use this, and we don't have a package available for it on RT
 #jmespath 
 msgpack>=1.0.0
 PyYAML
@@ -9,9 +9,9 @@ MarkupSafe
 requests<2.32.0 ; python_version < '3.10'
 requests>=2.32.3 ; python_version >= '3.10'
 certifi==2023.07.22; python_version < '3.10'
-# Allowing older version for certifi since we don't have >=2024.7.4 available on RT.
-# Salt was using version 2023 before upgrading to 2024.7.4.
-#certifi>=2024.7.4; python_version >= '3.10'
+# NI: Allowing older version for certifi since we don't have >=2024.7.4 available on RT;
+# salt was using version 2023 before upgrading to 2024.7.4.
+# certifi>=2024.7.4; python_version >= '3.10'
 certifi>=2024.2.2; python_version >= '3.10'
 distro>=1.0.1
 psutil<6.0.0; python_version <= '3.9'
@@ -19,13 +19,14 @@ psutil>=5.0.0; python_version >= '3.10'
 packaging>=21.3
 looseversion
 
-# Remove croniter as a dependency as this significantly increases the LinuxRT image size, and is used for chron jobs,
+# NI: Remove croniter as a dependency as this significantly increases the LinuxRT image size, and is used for chron jobs,
 # which we have not supported out of the box for salt 3000.2 either, as we did not install this dep previously.
 # croniter>=0.3.0,!=0.3.22; sys_platform != 'win32'
 
+# NI: We're removing this as a dependency because contextvars is available in the stdlib for Python >= 3.7.
 # We need contextvars for salt-ssh
-contextvars
+# contextvars
 cryptography>=42.0.0
-# Allowing newer urllib3 since newer salt versions have upgraded to >=2.0.0 without making modifications to the source code.
+# NI: Allowing newer urllib3 since newer salt versions have upgraded to >=2.0.0 without making modifications to the source code.
 # urllib3>=1.26.20,<2.0.0
 urllib3>=1.26.20

--- a/requirements/crypto.txt
+++ b/requirements/crypto.txt
@@ -1,6 +1,6 @@
 # NI: We want to use pycryptodome on LinuxRT as that's installed outside of salt and we want to conserve disk space.
 # Salt 3006.13 still has fallbacks to pycryptodome (i.e. it does "import Crypto" if "import Cryptodome" fails)
-# pycryptodomex>=3.9.8
+#pycryptodomex>=3.9.8
 pycryptodomex>=3.9.8; sys_platform != "linux"
 pycryptodome>=3.9.8; sys_platform == "linux"
 

--- a/requirements/crypto.txt
+++ b/requirements/crypto.txt
@@ -1,1 +1,6 @@
-pycryptodomex>=3.9.8
+# NI: We want to use pycryptodome on LinuxRT as that's installed outside of salt and we want to conserve disk space.
+# Salt 3006.13 still has fallbacks to pycryptodome (i.e. it does "import Crypto" if "import Cryptodome" fails)
+# pycryptodomex>=3.9.8
+pycryptodomex>=3.9.8; sys_platform != "linux"
+pycryptodome>=3.9.8; sys_platform == "linux"
+


### PR DESCRIPTION
Remove `contextvars` as a dependency as this is not needed for Python >= 3.7, where it is part of the stdlib. We're removing it so we don't get issues down the line on LinuxRT due to not installing it (disk space concerns).

Also, set `pycryptodome` as a dependency instead of `pycryptodomex` for Linux (Salt has built-in fallbacks to the non-x if `pycryptodomex` is not found). Doing this avoids us having to install bot the X and non-X on LinuxRT, which saves some disk space, as `pycryptodome` pulled anyway.

EXTRA: Prepend comments related to why we altered dependencies with "NI".