### PR TITLE
Fix log rotation on Windows

### DIFF
--- a/salt/_logging/handlers.py
+++ b/salt/_logging/handlers.py
@@ -14,6 +14,8 @@ from salt._logging.mixins import ExcInfoOnLogLevelFormatMixin
 
 # third party libraries
 if sys.platform.startswith("win"):
+    # Added by NI. Only needed on Windows where log rotation does not work
+    # properly when another process keeps a handle to the logfile open.
     import concurrent_log_handler
 
 log = logging.getLogger(__name__)

--- a/salt/_logging/handlers.py
+++ b/salt/_logging/handlers.py
@@ -161,6 +161,16 @@ class RotatingFileHandler(
             super().handleError(record)
 
 
+class ConcurrentRotatingFileHandler(
+    ExcInfoOnLogLevelFormatMixin, concurrent_log_handler.ConcurrentRotatingFileHandler
+):
+    """
+    Added by NI. Use third party ConcurrentRotatingFileHandler to address log rotation on Windows properly,
+    where a file can't be renamed if a handle to it is held by another process.
+    Concurrent Rotating file handler which properly handles exc_info on a per handler basis
+    """
+
+
 class WatchedFileHandler(
     ExcInfoOnLogLevelFormatMixin, logging.handlers.WatchedFileHandler
 ):

--- a/salt/_logging/handlers.py
+++ b/salt/_logging/handlers.py
@@ -12,6 +12,9 @@ from collections import deque
 
 from salt._logging.mixins import ExcInfoOnLogLevelFormatMixin
 
+# third party libraries
+import concurrent_log_handler
+
 log = logging.getLogger(__name__)
 
 

--- a/salt/_logging/handlers.py
+++ b/salt/_logging/handlers.py
@@ -13,7 +13,8 @@ from collections import deque
 from salt._logging.mixins import ExcInfoOnLogLevelFormatMixin
 
 # third party libraries
-import concurrent_log_handler
+if sys.platform.startswith("win"):
+    import concurrent_log_handler
 
 log = logging.getLogger(__name__)
 
@@ -163,15 +164,15 @@ class RotatingFileHandler(
         if not handled:
             super().handleError(record)
 
-
-class ConcurrentRotatingFileHandler(
-    ExcInfoOnLogLevelFormatMixin, concurrent_log_handler.ConcurrentRotatingFileHandler
-):
-    """
-    Added by NI. Use third party ConcurrentRotatingFileHandler to address log rotation on Windows properly,
-    where a file can't be renamed if a handle to it is held by another process.
-    Concurrent Rotating file handler which properly handles exc_info on a per handler basis
-    """
+if sys.platform.startswith("win"):
+    class ConcurrentRotatingFileHandler(
+        ExcInfoOnLogLevelFormatMixin, concurrent_log_handler.ConcurrentRotatingFileHandler
+    ):
+        """
+        Added by NI. Use third party ConcurrentRotatingFileHandler to address log rotation on Windows properly,
+        where a file can't be renamed if a handle to it is held by another process.
+        Concurrent Rotating file handler which properly handles exc_info on a per handler basis
+        """
 
 
 class WatchedFileHandler(

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -26,7 +26,8 @@ QUIET = logging.QUIET = 1000
 
 import salt.defaults.exitcodes  # isort:skip  pylint: disable=unused-import
 from salt._logging.handlers import DeferredStreamHandler  # isort:skip
-from salt._logging.handlers import ConcurrentRotatingFileHandler  # isort:skip
+if sys.platform.startswith("win"):
+    from salt._logging.handlers import ConcurrentRotatingFileHandler  # isort:skip
 from salt._logging.handlers import StreamHandler  # isort:skip
 from salt._logging.handlers import SysLogHandler  # isort:skip
 from salt._logging.handlers import WatchedFileHandler  # isort:skip
@@ -804,14 +805,24 @@ def setup_logfile_handler(
             # user is not using plain ASCII, their system should be ready to
             # handle UTF-8.
             if max_bytes > 0:
-                handler = ConcurrentRotatingFileHandler(
-                    log_path,
-                    mode="a",
-                    maxBytes=max_bytes,
-                    backupCount=backup_count,
-                    encoding="utf-8",
-                    delay=0,
-                )
+                if sys.platform.startswith("win"):
+                    handler = ConcurrentRotatingFileHandler(
+                        log_path,
+                        mode="a",
+                        maxBytes=max_bytes,
+                        backupCount=backup_count,
+                        encoding="utf-8",
+                        delay=0,
+                    )
+                else:
+                      handler = RotatingFileHandler(
+                        log_path,
+                        mode="a",
+                        maxBytes=max_bytes,
+                        backupCount=backup_count,
+                        encoding="utf-8",
+                        delay=0,
+                    )                  
             else:
                 handler = WatchedFileHandler(
                     log_path, mode="a", encoding="utf-8", delay=0

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -26,7 +26,7 @@ QUIET = logging.QUIET = 1000
 
 import salt.defaults.exitcodes  # isort:skip  pylint: disable=unused-import
 from salt._logging.handlers import DeferredStreamHandler  # isort:skip
-import RotatingFileHandler  # isort:skip
+ from salt._logging.handlers import RotatingFileHandler  # isort:skip
 if sys.platform.startswith("win"):
     from salt._logging.handlers import ConcurrentRotatingFileHandler  # isort:skip
 from salt._logging.handlers import StreamHandler  # isort:skip

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -26,7 +26,7 @@ QUIET = logging.QUIET = 1000
 
 import salt.defaults.exitcodes  # isort:skip  pylint: disable=unused-import
 from salt._logging.handlers import DeferredStreamHandler  # isort:skip
- from salt._logging.handlers import RotatingFileHandler  # isort:skip
+from salt._logging.handlers import RotatingFileHandler  # isort:skip
 if sys.platform.startswith("win"):
     from salt._logging.handlers import ConcurrentRotatingFileHandler  # isort:skip
 from salt._logging.handlers import StreamHandler  # isort:skip

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -816,7 +816,7 @@ def setup_logfile_handler(
                         delay=0,
                     )
                 else:
-                      handler = RotatingFileHandler(
+                    handler = RotatingFileHandler(
                         log_path,
                         mode="a",
                         maxBytes=max_bytes,

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -26,7 +26,7 @@ QUIET = logging.QUIET = 1000
 
 import salt.defaults.exitcodes  # isort:skip  pylint: disable=unused-import
 from salt._logging.handlers import DeferredStreamHandler  # isort:skip
-from salt._logging.handlers import RotatingFileHandler  # isort:skip
+from salt._logging.handlers import ConcurrentRotatingFileHandler  # isort:skip
 from salt._logging.handlers import StreamHandler  # isort:skip
 from salt._logging.handlers import SysLogHandler  # isort:skip
 from salt._logging.handlers import WatchedFileHandler  # isort:skip
@@ -804,7 +804,7 @@ def setup_logfile_handler(
             # user is not using plain ASCII, their system should be ready to
             # handle UTF-8.
             if max_bytes > 0:
-                handler = RotatingFileHandler(
+                handler = ConcurrentRotatingFileHandler(
                     log_path,
                     mode="a",
                     maxBytes=max_bytes,

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -26,9 +26,12 @@ QUIET = logging.QUIET = 1000
 
 import salt.defaults.exitcodes  # isort:skip  pylint: disable=unused-import
 from salt._logging.handlers import DeferredStreamHandler  # isort:skip
-from salt._logging.handlers import RotatingFileHandler  # isort:skip
 if sys.platform.startswith("win"):
+    # Added by NI. Only needed on Windows where log rotation does not work
+    # properly when another process keeps a handle to the logfile open.
     from salt._logging.handlers import ConcurrentRotatingFileHandler  # isort:skip
+else:
+    from salt._logging.handlers import RotatingFileHandler  # isort:skip
 from salt._logging.handlers import StreamHandler  # isort:skip
 from salt._logging.handlers import SysLogHandler  # isort:skip
 from salt._logging.handlers import WatchedFileHandler  # isort:skip
@@ -807,6 +810,8 @@ def setup_logfile_handler(
             # handle UTF-8.
             if max_bytes > 0:
                 if sys.platform.startswith("win"):
+                    # Added by NI. Only needed on Windows where log rotation does not work
+                    # properly when another process keeps a handle to the logfile open.                    
                     handler = ConcurrentRotatingFileHandler(
                         log_path,
                         mode="a",

--- a/salt/_logging/impl.py
+++ b/salt/_logging/impl.py
@@ -26,6 +26,7 @@ QUIET = logging.QUIET = 1000
 
 import salt.defaults.exitcodes  # isort:skip  pylint: disable=unused-import
 from salt._logging.handlers import DeferredStreamHandler  # isort:skip
+import RotatingFileHandler  # isort:skip
 if sys.platform.startswith("win"):
     from salt._logging.handlers import ConcurrentRotatingFileHandler  # isort:skip
 from salt._logging.handlers import StreamHandler  # isort:skip


### PR DESCRIPTION
Replace the stdlib `RotatingFileHandler` with `ConcurrentRotatingFileHandler` from third-party library [concurrent-log-handler](https://pypi.org/project/concurrent-log-handler/), which provides proper rotation support on Windows, where the stdlib variant fails to rotate logs if they are being opened by multiple processes. 

This does happen at least for the salt-master, where multiple processes can keep a handle open to the master logfile, and leads to a logging halt when the master logfile reaches its max size due to rotation not happening.

Conditional guards have been placed so that we only do this switch on Windows. We want to avoid using an extra third-party  dependency on LinuxRT, where some targets that we support have limited storage. Moreover, this is not even needed on Linux, as the OS supports renaming logfiles even when they are opened by other processes.

This PR is accompanied by one on AzDO, which installs this new dependency for Windows salt-master and salt-minion.