### PR TITLE
Skip revalidation of token for every event

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -2387,10 +2387,10 @@ class Events:
                 yield "retry: 400\n"
 
                 while True:
-                    # make sure the token is still valid
-                    if not self._is_valid_token(auth_token):
-                        logger.debug("Token is no longer valid")
-                        break
+                    # Skip revalidation of token as each check is done through a TCP connection, an approach which does not scale.
+                    # if not self._is_valid_token(auth_token):
+                    #     logger.debug("Token is no longer valid")
+                    #     break
 
                     data = next(stream)
                     yield "tag: {}\n".format(data.get("tag", ""))


### PR DESCRIPTION
This check currently gets the token through a TCP connection with each event produced by the salt master. This causes the following issues:

- When a large amount of events comes, existing connections on the `/events` route stop receiving any events.
- Salt requests a really large amount of memory (20GB), which results in OOM errors.

With this change, we go back to the previous behavior where the token is checked only once. This is not a problem for SLS since the communication for retrieving the events is internal. I validated that 100 minions work with no issues with this change, which didn't work before.