### PR TITLE
[transport/tcp.py] Create copy of clients list when iterating, to avoid races

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -910,7 +910,7 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
         if topic_list:
             for topic in topic_list:
                 sent = False
-                for client in self.clients:
+                for client in list(self.clients):
                     if topic == client.id_:
                         try:
                             # Write the packed str
@@ -922,7 +922,7 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
                 if not sent:
                     log.debug("Publish target %s not connected %r", topic, self.clients)
         else:
-            for client in self.clients:
+            for client in list(self.clients):
                 try:
                     # Write the packed str
                     yield client.stream.write(payload)


### PR DESCRIPTION
Convert self.clients to a list, when iterating over it in function `publish_payload` of `transport/tcp.py`, to avoid race conditions. This is already done on the saltstack 3007.x and master branches, but was not cherry-picked on 3006.x, on which we are based.

A similar change [was performed here, for the upstream 3006.x branch](https://github.com/saltstack/salt/pull/68434/changes#diff-96f30809cefae399bc3e39d1c1e526916dba5da3f758fe48cbf00bf8b62aa36e) when iterating on this list in other parts of the file, and that change was cherry-picked in ni/salt, too, in [this pull request](https://github.com/ni/salt/pull/82).

Without this, "set changed during iteration" errors such as the one below appear in the `salt-master` logs. Further investigation (we connected 50 clients, and raised a RuntimeError every 5 runs of `publish_payload`; we left this running for ~2 days) of these errors show that they are not fatal. Instead, rerunning a job (one/a few times) that fails due to the TCP transfer failing, normally fixes it. Nonetheless, it's better to avoid these races altogether.


2026-04-07 14:08:15,391 [tornado.application:640 ][ERROR   ][2336] Exception in callback functools.partial(<function wrap.<locals>.null_wrapper at 0x000001848DE22F80>, <salt.ext.tornado.concurrent.Future object at 0x00000184ABDE30D0>)
Traceback (most recent call last):
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\ioloop.py", line 606, in _run_callback
    ret = callback()
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\stack_context.py", line 278, in null_wrapper
    return fn(*args, **kwargs)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\ioloop.py", line 628, in _discard_future_result
    future.result()
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\channel\server.py", line 1030, in publish_payload
    ret = yield self.transport.publish_payload(payload)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\transport\tcp.py", line 1033, in publish_payload
    ret = yield self.pub_server.publish_payload(payload, *args)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1056, in run
    value = future.result()
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\concurrent.py", line 249, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 4, in raise_exc_info
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\ext\tornado\gen.py", line 1064, in run
    yielded = self.gen.throw(*exc_info)
  File "C:\Program Files\National Instruments\Shared\salt-master\bin\Lib\site-packages\salt\transport\tcp.py", line 925, in publish_payload
    for client in self.clients:
RuntimeError: Set changed size during iteration