### PR TITLE
Added timeout for sending the package to clients to avoid hangs. Sorted the None clients to latest in the list.

### DIFF
--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -937,7 +937,7 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
                     yield self._write_payload(client, payload)
                     log.debug("Finish sending to client %s (id=%r)", client.address, client.id_)
                 except salt.ext.tornado.gen.TimeoutError:
-                    log.debug("TIMEOUT writing payload (%d bytes) to client %s (id=%r)", len(payload), client.address, client.id_)
+                    log.warning("TIMEOUT writing payload (%d bytes) to client %s (id=%r)", len(payload), client.address, client.id_)
                     to_remove.append(client)
                 except salt.ext.tornado.iostream.StreamClosedError:
                     log.debug("Stream is closed for client %s (id=%r)", client.address, client.id_)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -901,6 +901,14 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
         self.clients.add(client)
         self.io_loop.spawn_callback(self._stream_read, client)
 
+    @salt.ext.tornado.gen.coroutine
+    def _write_payload(self, client, payload):
+        deadline = self.io_loop.time() + 5
+        yield salt.ext.tornado.gen.with_timeout(
+            deadline,
+            client.stream.write(payload),
+        )
+ 
     # TODO: ACK the publish through IPC
     @salt.ext.tornado.gen.coroutine
     def publish_payload(self, package, topic_list=None):
@@ -922,11 +930,17 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
                 if not sent:
                     log.debug("Publish target %s not connected %r", topic, self.clients)
         else:
-            for client in self.clients:
+            for client in sorted(self.clients, key=lambda c: c.id_ is None):
                 try:
                     # Write the packed str
-                    yield client.stream.write(payload)
+                    log.debug("Sending the package to client %s (id=%r)", client.address, client.id_)
+                    yield self._write_payload(client, payload)
+                    log.debug("Finish sending to client %s (id=%r)", client.address, client.id_)
+                except salt.ext.tornado.gen.TimeoutError:
+                    log.debug("TIMEOUT writing payload (%d bytes) to client %s (id=%r)", len(payload), client.address, client.id_)
+                    to_remove.append(client)
                 except salt.ext.tornado.iostream.StreamClosedError:
+                    log.debug("Stream is closed for client %s (id=%r)", client.address, client.id_)
                     to_remove.append(client)
         for client in to_remove:
             log.debug(


### PR DESCRIPTION
Added timeout for sending the package to clients to avoid hangs. Sorted the None clients to latest in the list.

### What does this PR do?
Added timeout to write_payload
Sorted the None Clients to latest

### What issues does this PR fix or reference?
Added timeout for sending the package to clients to avoid hangs. Sorted the None clients to latest in the list.
3845468
This is a hack and we suppose that the issue was introduced in new salt upgrade.
The write hangs indefinitely, we don't know exactly the root cause. We know that it happens on minions with None, which are bassically minions which lost connection and created a new one. 
We added a timeout for write calls to avoid hangs.
We expect that this issue is not present in the latest salt as we suppose that the latest Tornado solves this issue. 

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
