### PR TITLE
Fix master_uri_list initialization when eval_master is first called with failed=True (salt-call)

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -670,9 +670,16 @@ class MinionBase:
             conn = False
             last_exc = None
 
+            # In some execution paths (e.g. salt-call), eval_master() may be invoked
+            # with 'failed=True' even on the initial call. This prevents the original
+            # logic (which relies on 'if not failed') from initializing
+            # master_uri_list, leading to missing data and runtime errors.
+            is_first_call = not getattr(self, "_eval_master_called", False)
+            self._eval_master_called = True
+
             # if the connection to the saltmaster was lost,
             # don't reinitialize the uri list to keep using the same one
-            if not failed:
+            if is_first_call or not failed:
                 opts["master_uri_list"] = []
 
             opts["local_masters"] = copy.copy(opts["master"])
@@ -689,7 +696,7 @@ class MinionBase:
 
             # if the connection to the saltmaster was lost,
             # don't reinitialize the uri list to keep using the same one
-            if not failed:
+            if is_first_call or not failed:
                 # This sits outside of the connection loop below because it needs to set
                 # up a list of master URIs regardless of which masters are available
                 # to connect _to_. This is primarily used for masterless mode, when
@@ -729,7 +736,7 @@ class MinionBase:
                     opts["master"] = master
 
                     # look for a different ip only after attempting current one 3 times
-                    if not failed or (failed and attempts > 3):
+                    if is_first_call or not failed or (failed and attempts > 3):
                         opts.update(prep_ip_port(opts))
                         if opts["master_type"] == "failover":
                             try:

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -937,7 +937,7 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
                     yield self._write_payload(client, payload)
                     log.debug("Finish sending to client %s (id=%r)", client.address, client.id_)
                 except salt.ext.tornado.gen.TimeoutError:
-                    log.debug("TIMEOUT writing payload (%d bytes) to client %s (id=%r)", len(payload), client.address, client.id_)
+                    log.warning("TIMEOUT writing payload (%d bytes) to client %s (id=%r)", len(payload), client.address, client.id_)
                     to_remove.append(client)
                 except salt.ext.tornado.iostream.StreamClosedError:
                     log.debug("Stream is closed for client %s (id=%r)", client.address, client.id_)

--- a/salt/transport/tcp.py
+++ b/salt/transport/tcp.py
@@ -901,6 +901,14 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
         self.clients.add(client)
         self.io_loop.spawn_callback(self._stream_read, client)
 
+    @salt.ext.tornado.gen.coroutine
+    def _write_payload(self, client, payload):
+        deadline = self.io_loop.time() + 5
+        yield salt.ext.tornado.gen.with_timeout(
+            deadline,
+            client.stream.write(payload),
+        )
+ 
     # TODO: ACK the publish through IPC
     @salt.ext.tornado.gen.coroutine
     def publish_payload(self, package, topic_list=None):
@@ -922,11 +930,17 @@ class PubServer(salt.ext.tornado.tcpserver.TCPServer):
                 if not sent:
                     log.debug("Publish target %s not connected %r", topic, self.clients)
         else:
-            for client in self.clients:
+            for client in sorted(self.clients, key=lambda c: c.id_ is None):
                 try:
                     # Write the packed str
-                    yield client.stream.write(payload)
+                    log.debug("Sending the package to client %s (id=%r)", client.address, client.id_)
+                    yield self._write_payload(client, payload)
+                    log.debug("Finish sending to client %s (id=%r)", client.address, client.id_)
+                except salt.ext.tornado.gen.TimeoutError:
+                    log.debug("TIMEOUT writing payload (%d bytes) to client %s (id=%r)", len(payload), client.address, client.id_)
+                    to_remove.append(client)
                 except salt.ext.tornado.iostream.StreamClosedError:
+                    log.debug("Stream is closed for client %s (id=%r)", client.address, client.id_)
                     to_remove.append(client)
         for client in to_remove:
             log.debug(


### PR DESCRIPTION

### What does this PR do?

Ensures that `master_uri_list` is properly initialized on the first call to
`eval_master()`, even when `failed=True`.
This is achieved by introducing a lightweight runtime flag that detects the
first invocation of `eval_master()` and forces initialization in that case.

---

### What issues does this PR fix or reference?
Fixes improper initialization of `master_uri_list` when `eval_master()` is
called with `failed=True` on the first execution (for example in `salt-call`).

---

### Previous Behavior
Initialization of `master_uri_list` relied solely on:
if not failed:

---
### Testing
Tested on windows machine

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the test documentation for details on how to implement tests
into Salt's test suite:
https://docs.saltproject.io/en/master/topics/tutorials/writing_tests.html -->
- [ ] Docs
- [ ] Changelog - https://docs.saltproject.io/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

<!-- Please review Salt's Contributing Guide for best practices and guidance in
choosing the right branch:
https://docs.saltproject.io/en/master/topics/development/contributing.html -->

<!-- Additional guidance for pull requests can be found here:
https://docs.saltproject.io/en/master/topics/development/pull_requests.html -->

<!-- See GitHub's page on GPG signing for more information about signing commits
with GPG:
https://help.github.com/articles/signing-commits-using-gpg/ -->
